### PR TITLE
the radarr service was copied from sonarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For the newer Linuxserver Radarr builds based on mono the jrottenberg FFMpeg bui
 
 ~~~yml
 services:
-  sonarr:
+  radarr:
     image: mdhiggins/radarr-sma
     container_name: radarr
     volumes:


### PR DESCRIPTION
the radarr image was being loaded in the sonarr section of the services. looks like it was just a typo from copying the sonarr example over to the radarr docs