### PR TITLE
+x to postRadarr.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,4 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
+RUN chmod +x ${SMA_PATH}/postRadarr.sh

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -39,3 +39,4 @@ VOLUME /usr/local/sma/config
 # update.py sets FFMPEG/FFPROBE paths, updates API key and Sonarr/Radarr settings in autoProcess.ini
 COPY extras/ ${SMA_PATH}/
 COPY root/ /
+RUN chmod +x ${SMA_PATH}/postRadarr.sh


### PR DESCRIPTION
Resolves #55 . By default the `postRadarr.sh` script is not executable. It is copied from /extras into the local SMA folder in the container. This presents problems when updating the container because any permissions modifications done manually are wiped out when the container rebuilds. The end result being an upgrade can break a working system.